### PR TITLE
RDKEMW-4586 : Fix for bug Markers not generated

### DIFF
--- a/scripts/logMilestone.sh
+++ b/scripts/logMilestone.sh
@@ -42,10 +42,14 @@ MILESTONE_EVENT=$1
 if [ -f "$UPTIME_BIN" ]; then
     #write uptime using rdkLogMileStone binary
     uptime=`$UPTIME_BIN $1`
+    uptime_seconds=$(cut -d ' ' -f 1 /proc/uptime)
+    uptime_ms=$(awk -v up="$uptime_seconds" 'BEGIN { printf "%.0f", up * 1000 }')
+
+    echo "Uptime_MS = $uptime_ms"
     if [ "$1" == "CONNECT_TO_NTP_SERVER" ]; then
-        t2ValNotify "btime_ntpConnTime_split" "$uptime"
+        t2ValNotify "btime_ntpConnTime_split" "$uptime_ms"
     elif [ "$1" == "RDK_STARTED" ]; then
-        t2ValNotify "btime_rdkstart_split" "$uptime"
+        t2ValNotify "btime_rdkstart_split" "$uptime_ms"
     fi
 else
     echo "$UPTIME_BIN not found..!"


### PR DESCRIPTION
Reason for Change : Marker which is sent using tvalNotify is failing since the uptime is NULL. 
 root@element-teone:~# 2025-05-27 03:49:39 : t2_event_s ++in
 2025-05-27 03:49:39 : marker = btime_ntpConnTime_split : value 

Hence changes done to calculate the uptime value.