### PR TITLE
RDKB-61752 : Add Legacy Function for Backward Compatibility 

### DIFF
--- a/include/rdk_logger.h
+++ b/include/rdk_logger.h
@@ -285,6 +285,15 @@ void rdk_logger_log_onboard(const char *module, const char *msg, ...) __attribut
 void rdk_dbg_MsgRaw(rdk_LogLevel level, const char *module, const char *format, ...) __attribute__ ((format (printf, 3, 4)));
 
 /**
+ * @brief legacy method to Log a message using a va_list.
+ * @param level Log level.
+ * @param module Module name.
+ * @param format Printf-style format string.
+ * @param args va_list of arguments.
+ */
+void rdk_dbg_MsgRaw1(rdk_LogLevel level, const char *module, const char *format, va_list args);
+
+/**
  * @brief Convert a log level string to rdk_LogLevel enum.
  * @param level Log level as string (e.g., "INFO", "DEBUG").
  * @return Corresponding rdk_LogLevel value, or RDK_LOG_NONE if invalid.

--- a/src/rdk_debug.c
+++ b/src/rdk_debug.c
@@ -100,6 +100,11 @@ void rdk_logger_msg_vsprintf(rdk_LogLevel level, const char *module, const char 
     rdk_dbg_priv_log_msg(level, module, format, args);
 }
 
+void rdk_dbg_MsgRaw1(rdk_LogLevel level, const char *module, const char *format, va_list args)
+{
+    rdk_dbg_priv_log_msg(level, module, format, args);
+}
+
 /**
  * @brief Function to sets a specific log level of a module.
  *


### PR DESCRIPTION
Reason for change: Add rdk_dbg_* APIs for Backward Compatibility
Test Procedure: Verify WiFi Motion
Risks: Low
Signed-off-by: dshett549 [DEEPTHICHANDRASHEKAR_SHETTY@comcast.com](mailto:DEEPTHICHANDRASHEKAR_SHETTY@comcast.com)